### PR TITLE
Add scenario13 with break/fix of the FIP port forwarding

### DIFF
--- a/osp-workshop-common
+++ b/osp-workshop-common
@@ -1,4 +1,4 @@
-SCENARIO_NUM=$(ls -d $WORKDIR/roles/scenario* | sed 's/.*scenario\([0-9]*\)/\1/g' | sort | tail -n1)
+SCENARIO_NUM=$(ls -d $WORKDIR/roles/scenario* | sed 's/.*scenario\([0-9]*\)/\1/g' | sort -n | tail -n1)
 
 DEFAULT_BACKUP_NAME=backup
 

--- a/roles/scenario13/defaults/main.yml
+++ b/roles/scenario13/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+overcloudrc_file: /home/stack/overcloudrc
+public_network: public
+create_env_file: /home/stack/create_env.sh
+ssh_key_file: /tmp/scenario-{{ scenario }}-key.pem
+image_name: "cirros-0.5.2-x86_64"
+image_url: "http://download.cirros-cloud.net/0.5.2/cirros-0.5.2-x86_64-disk.img"
+image_file_name: "{{ working_dir }}/{{ image_name }}.img"
+project_net_segment: 1000
+project_net_physnet: "datacentre"
+temp_results_file: "/tmp/scenario-{{ scenario }}-data"
+pf_tcp_port: 1022

--- a/roles/scenario13/tasks/break.yml
+++ b/roles/scenario13/tasks/break.yml
@@ -1,0 +1,42 @@
+---
+- name: "create scenario {{ scenario}} working directory"
+  ansible.builtin.file:
+    path: "{{ working_dir }}/.scenario{{ scenario }}"
+    state: directory
+
+- name: Ensure that required packages are installed
+  become: true
+  ansible.builtin.package:
+    name: "{{ item }}"
+    state: present
+    use: dnf
+  with_items:
+    - jq
+    - openssh
+
+- name: Upload scenario
+  ansible.builtin.template:
+    src: create_env.sh.j2
+    dest: "{{ create_env_file }}"
+    mode: '0755'
+
+- name: Execute environment
+  ansible.builtin.shell: "{{ create_env_file }}"
+  register: floating_ip
+
+- name: Delete environment file
+  ansible.builtin.file:
+    path: "{{ create_env_file }}"
+    state: absent
+
+- name: Fetch SSH key file
+  ansible.builtin.fetch:
+    src: "{{ ssh_key_file }}"
+    dest: "{{ ssh_key_file }}"
+    flat: yes
+
+- name: Create message
+  ansible.builtin.copy:
+    dest: "{{ workshop_message_file }}"
+    content: "Run the following command: \nssh -p {{ pf_tcp_port }} -i {{ ssh_key_file }} cirros@{{ floating_ip.stdout_lines[-1] }}\n"
+  delegate_to: 127.0.0.1

--- a/roles/scenario13/tasks/cleanup.yml
+++ b/roles/scenario13/tasks/cleanup.yml
@@ -1,0 +1,38 @@
+---
+- name: "delete OpenStack resources for scenario {{ scenario }}"
+  shell: |
+    {{ osp_get_credentials_cmd }}
+
+    if [ -f {{ temp_results_file }} ]; then
+      source {{ temp_results_file }}
+      {{ oc_osp_cmd }} openstack floating ip delete $fip_id
+      for pf in $({{ oc_osp_cmd }} openstack floating ip port forwarding list $pf_fip_id -c ID -f value); do
+        {{ oc_osp_cmd }} openstack floating ip port forwarding delete $pf_fip_id $pf
+      done
+      sleep 2
+      {{ oc_osp_cmd }} openstack floating ip delete $pf_fip_id
+    fi
+
+    {{ oc_osp_cmd }} openstack server delete scenario-{{ scenario }}-fip-vm
+    {{ oc_osp_cmd }} openstack server delete scenario-{{ scenario }}-pf-vm
+
+    {{ oc_osp_cmd }} openstack keypair delete scenario-{{ scenario }}-key
+
+    {{ oc_osp_cmd }} openstack router remove subnet scenario-{{ scenario }}-router scenario-{{ scenario }}-subnet
+    {{ oc_osp_cmd }} openstack router delete scenario-{{ scenario }}-router
+
+    {{ oc_osp_cmd }} openstack security group delete scenario-{{ scenario }}-sg
+
+    for net in $({{ oc_osp_cmd }} openstack network list | grep scenario-{{ scenario }}-network | awk '{ print $2 }'); do
+      {{ oc_osp_cmd }} openstack network delete $net
+    done
+
+- name: "delete scenario {{ scenario }} working directory"
+  ansible.builtin.file:
+    path: "{{ working_dir }}/.scenario{{ scenario }}"
+    state: absent
+
+- name: "delete scenario {{ scenario }} temporary results file"
+  ansible.builtin.file:
+    path: "{{ temp_results_file }}"
+    state: absent

--- a/roles/scenario13/tasks/fix.yml
+++ b/roles/scenario13/tasks/fix.yml
@@ -1,0 +1,35 @@
+---
+- name: fix the scenario {{ scenario }}
+  ansible.builtin.shell: |
+    {{ osp_get_credentials_cmd }}
+
+    source {{ temp_results_file }}
+
+    for pf in $({{ oc_osp_cmd }} openstack floating ip port forwarding list $pf_fip_id -c ID -f value); do
+      {{ oc_osp_cmd }} openstack floating ip port forwarding delete $pf_fip_id $pf
+    done
+
+    {{ oc_osp_cmd }} openstack server delete scenario-{{ scenario }}-fip-vm
+    {{ oc_osp_cmd }} openstack server delete scenario-{{ scenario }}-pf-vm
+
+    {{ oc_osp_cmd }} openstack router remove subnet scenario-{{ scenario }}-router scenario-{{ scenario }}-subnet
+
+    for net in $({{ oc_osp_cmd }} openstack network list | grep scenario-{{ scenario }}-network | awk '{ print $2 }'); do
+      {{ oc_osp_cmd }} openstack network delete $net
+    done
+
+    {{ oc_osp_cmd }} openstack network create --provider-network-type geneve scenario-{{ scenario }}-network
+    {{ oc_osp_cmd }} openstack subnet create --network scenario-{{ scenario }}-network --subnet-range 192.168.1{{ scenario }}.0/24 scenario-{{ scenario }}-subnet
+    {{ oc_osp_cmd }} openstack router add subnet scenario-{{ scenario }}-router scenario-{{ scenario }}-subnet
+
+    {{ oc_osp_cmd }} openstack server create --flavor m1.small --image {{ image_name }} --nic net-id=scenario-{{ scenario }}-network --key-name scenario-{{ scenario }}-key --security-group scenario-{{ scenario }}-sg scenario-{{ scenario }}-fip-vm --wait
+    {{ oc_osp_cmd }} openstack server show scenario-{{ scenario }}-fip-vm | grep -q "status.*ACTIVE"
+
+    port_id=$({{ oc_osp_cmd }} openstack port list --server scenario-{{ scenario }}-fip-vm -c ID -f value | head)
+    {{ oc_osp_cmd }} openstack floating ip set --port $port_id $fip_id
+
+    {{ oc_osp_cmd }} openstack server create --flavor m1.small --image {{ image_name }} --nic net-id=scenario-{{ scenario }}-network --key-name scenario-{{ scenario }}-key --security-group scenario-{{ scenario }}-sg scenario-{{ scenario }}-pf-vm --wait
+    {{ oc_osp_cmd }} openstack server show scenario-{{ scenario }}-fip-vm | grep -q "status.*ACTIVE"
+    pf_port_id=$({{ oc_osp_cmd }} openstack port list --server scenario-{{ scenario }}-pf-vm -c ID -f value | head)
+    pf_port_ip_address=$({{ oc_osp_cmd }} openstack port show $pf_port_id -f json | jq -r '.fixed_ips[0].ip_address')
+    {{ oc_osp_cmd }} openstack floating ip port forwarding create --internal-ip-address $pf_port_ip_address --port $pf_port_id --internal-protocol-port 22 --external-protocol-port {{ pf_tcp_port }} --protocol tcp $pf_fip_id

--- a/roles/scenario13/tasks/grade.yml
+++ b/roles/scenario13/tasks/grade.yml
@@ -1,0 +1,6 @@
+---
+- name: grade
+  ansible.builtin.shell: |
+    ssh_command=$(tail -n1 {{ workshop_message_file }})
+    user=$($ssh_command -o StrictHostKeyChecking=no whoami)
+    [ "$user" == "cirros" ]

--- a/roles/scenario13/tasks/main.yml
+++ b/roles/scenario13/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+- name: "Load {{ installer }} variables"
+  ansible.builtin.include_vars: "{{ installer }}.yml"
+  tags: always
+
+- name: Run scenario on the Tripleo environment
+  ansible.builtin.include_tasks: scenario.yml
+  when: installer == 'tripleo'
+  args:
+    apply:
+      when: inventory_hostname.startswith('undercloud')
+  tags: always
+
+- name: Run scenario on the Podified environment
+  ansible.builtin.include_tasks: scenario.yml
+  when: installer == 'podified'
+  args:
+    apply:
+      delegate_to: 127.0.0.1
+      run_once: true
+  tags: always

--- a/roles/scenario13/tasks/scenario.yml
+++ b/roles/scenario13/tasks/scenario.yml
@@ -1,0 +1,28 @@
+---
+- name: break environment - run undercloud tasks
+  ansible.builtin.include_tasks:
+    file: break.yml
+    apply:
+      tags: break
+  tags: break
+
+- name: grade environment - run undercloud tasks
+  ansible.builtin.include_tasks:
+    file: grade.yml
+    apply:
+      tags: grade
+  tags: grade
+
+- name: fix environment - run undercloud tasks
+  ansible.builtin.include_tasks:
+    file: fix.yml
+    apply:
+      tags: fix
+  tags: fix
+
+- name: cleanup environment - run undercloud tasks
+  ansible.builtin.include_tasks:
+    file: cleanup.yml
+    apply:
+      tags: cleanup
+  tags: cleanup

--- a/roles/scenario13/templates/create_env.sh.j2
+++ b/roles/scenario13/templates/create_env.sh.j2
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+set -e
+
+{{ osp_get_credentials_cmd }}
+
+if ! {{ oc_osp_cmd }} openstack network show {{ public_network }} > /dev/null 2> /dev/null; then
+    {{ oc_osp_cmd }} openstack network create --external --provider-network-type flat --provider-physical-network datacentre {{ public_network }}
+    {{ oc_osp_cmd }} openstack subnet create --no-dhcp --gateway 10.0.0.1 --network {{ public_network }} --subnet-range 10.0.0.0/24 --allocation-pool start=10.0.0.151,end=10.0.0.254 {{ public_network }}_subnet
+fi
+
+if ! {{ oc_osp_cmd }} openstack image show {{ image_name }} > /dev/null 2> /dev/null; then
+    # Create Cirros image
+    if [ ! -f {{ image_file_name }} ]; then
+        curl -L {{ image_url }} > {{ image_file_name }}
+    fi
+    {{ oc_osp_cmd }} openstack image create {{ image_name }} --disk-format qcow2 --container-format bare --public < {{ image_file_name }}
+fi
+
+{{ oc_osp_cmd }} openstack network create --provider-network-type vlan --provider-segment {{ project_net_segment }} --provider-physical-network {{ project_net_physnet }} scenario-{{ scenario }}-network
+
+{{ oc_osp_cmd }} openstack subnet create --network scenario-{{ scenario }}-network scenario-{{ scenario }}-subnet --subnet-range 192.168.1{{ scenario }}.0/24
+
+{{ oc_osp_cmd }} openstack router create scenario-{{ scenario }}-router
+
+{{ oc_osp_cmd }} openstack router set --enable-snat --external-gateway {{ public_network }} scenario-{{ scenario }}-router
+{{ oc_osp_cmd }} openstack router add subnet scenario-{{ scenario }}-router scenario-{{ scenario }}-subnet
+
+{{ oc_osp_cmd }} openstack flavor show m1.small > /dev/null 2> /dev/null || {{ oc_osp_cmd }} openstack flavor create m1.small --disk 1 --vcpus 1 --ram 512
+
+{{ oc_osp_cmd }} openstack security group create scenario-{{ scenario }}-sg
+{{ oc_osp_cmd }} openstack security group rule create --ingress --protocol icmp scenario-{{ scenario }}-sg
+{{ oc_osp_cmd }} openstack security group rule create --ingress --protocol tcp --dst-port 22 scenario-{{ scenario }}-sg
+{{ oc_osp_cmd }} openstack security group rule create --ingress --protocol tcp --dst-port {{ pf_tcp_port }} scenario-{{ scenario }}-sg
+
+# TODO(slaweq): We can revert that to use OSC to generate ssh keys for us once
+#   we will be using python-openstackclient >= 6.3.0 which contains patch
+#   https://review.opendev.org/c/openstack/python-openstackclient/+/881822
+yes | ssh-keygen -t ecdsa -f {{ ssh_key_file }} -N "" > /dev/null
+{% if installer == 'podified' %}
+{{ oc_bin }} -n {{ oc_namespace }} cp {{ ssh_key_file }}.pub openstackclient:/tmp/ssh_key.pub
+{{ oc_osp_cmd }} openstack keypair create --public-key /tmp/ssh_key.pub scenario-{{ scenario }}-key
+{% else %}
+{{ oc_osp_cmd }} openstack keypair create --public-key {{ ssh_key_file }}.pub scenario-{{ scenario }}-key
+{% endif %}
+
+{{ oc_osp_cmd }} openstack server create --flavor m1.small --image {{ image_name }} --nic net-id=scenario-{{ scenario }}-network --key-name scenario-{{ scenario }}-key --security-group scenario-{{ scenario }}-sg scenario-{{ scenario }}-fip-vm --wait
+{{ oc_osp_cmd }} openstack server show scenario-{{ scenario }}-fip-vm | grep -q "status.*ACTIVE"
+
+port_id=$({{ oc_osp_cmd }} openstack port list --server scenario-{{ scenario }}-fip-vm -c ID -f value | head)
+fip_id=$({{ oc_osp_cmd }} openstack floating ip create --port $port_id {{ public_network }} -c id -f value)
+fip_ip=$({{ oc_osp_cmd }} openstack floating ip show $fip_id -c floating_ip_address -f value)
+
+
+{{ oc_osp_cmd }} openstack server create --flavor m1.small --image {{ image_name }} --nic net-id=scenario-{{ scenario }}-network --key-name scenario-{{ scenario }}-key --security-group scenario-{{ scenario }}-sg scenario-{{ scenario }}-pf-vm --wait
+{{ oc_osp_cmd }} openstack server show scenario-{{ scenario }}-fip-vm | grep -q "status.*ACTIVE"
+
+pf_port_id=$({{ oc_osp_cmd }} openstack port list --server scenario-{{ scenario }}-pf-vm -c ID -f value | head)
+pf_port_ip_address=$({{ oc_osp_cmd }} openstack port show $pf_port_id -f json | jq -r '.fixed_ips[0].ip_address')
+pf_fip_id=$({{ oc_osp_cmd }} openstack floating ip create {{ public_network }} -c id -f value)
+pf_fip_ip=$({{ oc_osp_cmd }} openstack floating ip show $pf_fip_id -c floating_ip_address -f value)
+
+{{ oc_osp_cmd }} openstack floating ip port forwarding create --internal-ip-address $pf_port_ip_address --port $pf_port_id --internal-protocol-port 22 --external-protocol-port {{ pf_tcp_port }} --protocol tcp $pf_fip_id
+
+# Store useful info to the temporary file:
+echo "fip_id=$fip_id" > {{ temp_results_file }}
+echo "pf_fip_id=$pf_fip_id" >> {{ temp_results_file }}
+
+echo "$pf_fip_ip"

--- a/roles/scenario13/vars/podified.yml
+++ b/roles/scenario13/vars/podified.yml
@@ -1,0 +1,5 @@
+---
+container_run_cmd: "{{ oc_bin }} -n {{ oc_namespace }} exec --stdin=true"
+oc_osp_cmd: "{{ container_run_cmd }} openstackclient --"
+osp_get_credentials_cmd: ""
+ovn_controller_service_name: "edpm_ovn_controller"

--- a/roles/scenario13/vars/tripleo.yml
+++ b/roles/scenario13/vars/tripleo.yml
@@ -1,0 +1,5 @@
+---
+container_run_cmd: "podman exec -it"
+oc_osp_cmd: ""
+osp_get_credentials_cmd: "source {{ overcloudrc_file }}"
+ovn_controller_service_name: "tripleo_ovn_controller"


### PR DESCRIPTION
This patch adds new role for the scenario13 which is focused on the floating ip port forwarding.

Scenario first creates "vlan" tenant network and attaches 2 VMs to it. One of the VMs have Floating IP associated (this is distributed) and other have FIP Port Forwarding (this traffic should be centralized). Such configuration is not supported by Neutron thus FIP PF's connection don't work.

As fix for that issue, there is new "geneve" network created and VMs are recreated and connected to that new network.
    
Closes: #OSPRH-6202