### PR TITLE
[Scenario 2] Change size of the "broken" image to be 0 bytes

### DIFF
--- a/roles/scenario2/templates/create_env.sh.j2
+++ b/roles/scenario2/templates/create_env.sh.j2
@@ -21,7 +21,7 @@ fi
 # Create bad image
 image_file={{ working_dir }}/.scenario{{ scenario }}/scenario-{{ scenario }}-image.img
 if [ ! -e $image_file ]; then
-    /bin/qemu-img create -f qcow2 $image_file 100M
+    /bin/qemu-img create -f qcow2 $image_file 0b
 fi
 $OC_COMMAND openstack image create scenario-{{ scenario }}-image --disk-format qcow2 --container-format bare --public < $image_file
 


### PR DESCRIPTION
Guides to that scenario says about checking size of the image in Glance, previously when it was simply empty file, size was 0 and now it should still be 0 bytes.