### PR TITLE
Set jump host in lab script and make sure no old fingerprint exists

### DIFF
--- a/lab
+++ b/lab
@@ -8,6 +8,8 @@ WORKING_DIR=~/osp_training
 INVENTORY_FILE=$WORKING_DIR/ansible_inventory.yml
 WORKSHOP_MESSAGE_FILE="$WORKING_DIR/.scenario$2/message"
 ROLES_DIR=$WORKING_DIR/scenarios_repo
+SSH_CONFIG=$HOME/.ssh/config
+SSH_KNOWN_HOSTS=$HOME/.ssh/known_hosts
 
 # Error codes
 E_BAD_INPUT=2
@@ -40,6 +42,9 @@ else
         if ! /sbin/ip route | grep -q "$osp_subnet via $utility_ip"; then
                 sudo /sbin/ip route add $osp_subnet via $utility_ip dev $nic
         fi
+
+        configure_ssh_jump_host "lab@utility"
+
         ANSIBLE_CMD="ansible-playbook \
                 -i $INVENTORY_FILE \
                 --private-key $ssh_key_file \
@@ -56,6 +61,23 @@ else
                 -e create_env_file=$WORKING_DIR/create_env.sh"
 fi
 
+function configure_ssh_jump_host() {
+    local jump_host=$1
+    if grep -q "ProxyJump $jump_host" $SSH_CONFIG; then
+        return
+    fi
+    for hostname in $(grep ansible_host $inventory_file | awk -F':' '{print $2}'); do
+        cat <<EOF >>$SSH_CONFIG
+Host $hostname
+    ProxyJump $jump_host
+EOF
+    done
+    # We also need to make sure that the known_hosts file is empty otherwise
+    # when the env was stoped and then started again ssh to the compute
+    # nodes through the jump host will not be possible
+    rm $SSH_KNOWN_HOSTS
+
+}
 
 function errcho() {
     >&2 echo "$1"

--- a/osp-workshop-2024.sh
+++ b/osp-workshop-2024.sh
@@ -88,6 +88,11 @@ Host $hostname
     ProxyJump $jump_host
 EOF
     done
+
+    # We also need to make sure that the known_hosts file is empty otherwise
+    # when the env was stoped and then started again ssh to the compute
+    # nodes through the jump host will not be possible
+    rm $SSH_KNOWN_HOSTS
 }
 
 function ensure_private_key_exists() {


### PR DESCRIPTION
Previously SSH connection to the compute nodes through the lab@utility server as jump host was only configured by the osp-workshop helper script but as this is really needed on the lab environment for all of the scenarios run with RHOSO 18 this patch adds configuration of the jump host for the compute nodes also in the the lab script.

Additionally this patch removes existing ~/.ssh/known_hosts file to make sure that there is not issue with host keys verification after e.g. lab stop and then started again.