### PR TITLE
Fix way how public subnet check is done

### DIFF
--- a/roles/scenariobfx019/templates/create_env.sh.j2
+++ b/roles/scenariobfx019/templates/create_env.sh.j2
@@ -8,7 +8,8 @@ OC_COMMAND="{{ oc_osp_cmd }}"
 if ! $OC_COMMAND openstack network show {{ public_network }} > /dev/null 2> /dev/null; then
     $OC_COMMAND openstack network create --external --provider-network-type flat --provider-physical-network datacentre {{ public_network }}
 fi
-if ! $OC_COMMAND openstack subnet show {{ public_network }}_subnet > /dev/null 2> /dev/null; then
+public_subnets=$($OC_COMMAND openstack subnet list --network {{ public_network }} -c ID -f value | tr -d '[]')
+if [ -z "$public_subnets" ]; then
     $OC_COMMAND openstack subnet create --no-dhcp --gateway {{ public_network_gw_ip }} --network {{ public_network }} --subnet-range {{ public_network_subnet_range }} --allocation-pool start={{ public_network_ip_allocation_start }},end={{ public_network_ip_allocation_end }} {{ public_network }}_subnet
 fi
 

--- a/roles/scenariobfx020/templates/create_env.sh.j2
+++ b/roles/scenariobfx020/templates/create_env.sh.j2
@@ -8,7 +8,8 @@ OC_COMMAND="{{ oc_osp_cmd }}"
 if ! $OC_COMMAND openstack network show {{ public_network }} > /dev/null 2> /dev/null; then
     $OC_COMMAND openstack network create --external --provider-network-type flat --provider-physical-network datacentre {{ public_network }}
 fi
-if ! $OC_COMMAND openstack subnet show {{ public_network }}_subnet > /dev/null 2> /dev/null; then
+public_subnets=$($OC_COMMAND openstack subnet list --network {{ public_network }} -c ID -f value | tr -d '[]')
+if [ -z "$public_subnets" ]; then
     $OC_COMMAND openstack subnet create --no-dhcp --gateway {{ public_network_gw_ip }} --network {{ public_network }} --subnet-range {{ public_network_subnet_range }} --allocation-pool start={{ public_network_ip_allocation_start }},end={{ public_network_ip_allocation_end }} {{ public_network }}_subnet
 fi
 

--- a/roles/scenariobfx021/templates/create_env.sh.j2
+++ b/roles/scenariobfx021/templates/create_env.sh.j2
@@ -8,7 +8,8 @@ OC_COMMAND="{{ oc_osp_cmd }}"
 if ! $OC_COMMAND openstack network show {{ public_network }} > /dev/null 2> /dev/null; then
     $OC_COMMAND openstack network create --external --provider-network-type flat --provider-physical-network datacentre {{ public_network }}
 fi
-if ! $OC_COMMAND openstack subnet show {{ public_network }}_subnet > /dev/null 2> /dev/null; then
+public_subnets=$($OC_COMMAND openstack subnet list --network {{ public_network }} -c ID -f value | tr -d '[]')
+if [ -z "$public_subnets" ]; then
     $OC_COMMAND openstack subnet create --no-dhcp --gateway {{ public_network_gw_ip }} --network {{ public_network }} --subnet-range {{ public_network_subnet_range }} --allocation-pool start={{ public_network_ip_allocation_start }},end={{ public_network_ip_allocation_end }} {{ public_network }}_subnet
 fi
 

--- a/roles/scenariobfx022/templates/create_env.sh.j2
+++ b/roles/scenariobfx022/templates/create_env.sh.j2
@@ -8,7 +8,8 @@ OC_COMMAND="{{ oc_osp_cmd }}"
 if ! $OC_COMMAND openstack network show {{ public_network }} > /dev/null 2> /dev/null; then
     $OC_COMMAND openstack network create --external --provider-network-type flat --provider-physical-network datacentre {{ public_network }}
 fi
-if ! $OC_COMMAND openstack subnet show {{ public_network }}_subnet > /dev/null 2> /dev/null; then
+public_subnets=$($OC_COMMAND openstack subnet list --network {{ public_network }} -c ID -f value | tr -d '[]')
+if [ -z "$public_subnets" ]; then
     $OC_COMMAND openstack subnet create --no-dhcp --gateway {{ public_network_gw_ip }} --network {{ public_network }} --subnet-range {{ public_network_subnet_range }} --allocation-pool start={{ public_network_ip_allocation_start }},end={{ public_network_ip_allocation_end }} {{ public_network }}_subnet
 fi
 

--- a/roles/scenariobfx023/templates/create_env.sh.j2
+++ b/roles/scenariobfx023/templates/create_env.sh.j2
@@ -7,7 +7,8 @@ set -e
 if ! {{ oc_osp_cmd }} openstack network show {{ public_network }} > /dev/null 2> /dev/null; then
     {{ oc_osp_cmd }} openstack network create --external --provider-network-type flat --provider-physical-network datacentre {{ public_network }}
 fi
-if ! {{ oc_osp_cmd }} openstack subnet show {{ public_network }}_subnet > /dev/null 2> /dev/null; then
+public_subnets=$({{ oc_osp_cmd }} openstack subnet list --network {{ public_network }} -c ID -f value | tr -d '[]')
+if [ -z "$public_subnets" ]; then
     {{ oc_osp_cmd }} openstack subnet create --no-dhcp --gateway {{ public_network_gw_ip }} --network {{ public_network }} --subnet-range {{ public_network_subnet_range }} --allocation-pool start={{ public_network_ip_allocation_start }},end={{ public_network_ip_allocation_end }} {{ public_network }}_subnet
 fi
 

--- a/roles/scenariobfx026/templates/create_env.sh.j2
+++ b/roles/scenariobfx026/templates/create_env.sh.j2
@@ -7,7 +7,8 @@ set -e
 if ! {{ oc_osp_cmd }} openstack network show {{ public_network }} > /dev/null 2> /dev/null; then
     {{ oc_osp_cmd }} openstack network create --external --provider-network-type flat --provider-physical-network datacentre {{ public_network }}
 fi
-if ! {{ oc_osp_cmd }} openstack subnet show {{ public_network }}_subnet > /dev/null 2> /dev/null; then
+public_subnets=$({{ oc_osp_cmd }} openstack subnet list --network {{ public_network }} -c ID -f value | tr -d '[]')
+if [ -z "$public_subnets" ]; then
     {{ oc_osp_cmd }} openstack subnet create --no-dhcp --gateway {{ public_network_gw_ip }} --network {{ public_network }} --subnet-range {{ public_network_subnet_range }} --allocation-pool start={{ public_network_ip_allocation_start }},end={{ public_network_ip_allocation_end }} {{ public_network }}_subnet
 fi
 

--- a/roles/scenariobfx027/templates/create_env.sh.j2
+++ b/roles/scenariobfx027/templates/create_env.sh.j2
@@ -7,7 +7,8 @@ set -e
 if ! {{ oc_osp_cmd }} openstack network show {{ public_network }} > /dev/null 2> /dev/null; then
     {{ oc_osp_cmd }} openstack network create --external --provider-network-type flat --provider-physical-network datacentre {{ public_network }}
 fi
-if ! {{ oc_osp_cmd }} openstack subnet show {{ public_network }}_subnet > /dev/null 2> /dev/null; then
+public_subnets=$({{ oc_osp_cmd }} openstack subnet list --network {{ public_network }} -c ID -f value | tr -d '[]')
+if [ -z "$public_subnets" ]; then
     {{ oc_osp_cmd }} openstack subnet create --no-dhcp --gateway {{ public_network_gw_ip }} --network {{ public_network }} --subnet-range {{ public_network_subnet_range }} --allocation-pool start={{ public_network_ip_allocation_start }},end={{ public_network_ip_allocation_end }} {{ public_network }}_subnet
 fi
 


### PR DESCRIPTION
Previously check if public subnet exists was based on the subnet's name but apparently name can vary in the lab environments so with this patch it checks if there are any subnets in the public network and if there are no, new public subnet is created.