### PR TITLE
Ignore invalid characters in the inventory's group name

### DIFF
--- a/lab
+++ b/lab
@@ -117,6 +117,9 @@ else
         osp_allocation_start=192.168.51.151
         osp_allocation_end=192.168.51.199
         utility_ip=172.25.250.253
+        # We don't want to write ansible WARNING about invalid characters in
+        # the inventory's group name so lets ignore it:
+        export ANSIBLE_TRANSFORM_INVALID_GROUP_CHARS=ignore
 
         # We need to make sure that directory where message file will be stored exists
         if [ ! -d "$WORKING_DIR/.scenario$2" ]; then


### PR DESCRIPTION
Edpm compute nodes' group in in the prepared inventory file for Ansible may contain character treated as invalid by Ansible. By default this is causing some Warning message produced by the Ansible. To avoid that warning, which don't really impacts lab script execution let's set Ansible to "ignore" that. More details about this specific config knob in Ansible is in [1].

[1] https://docs.ansible.com/ansible/latest/reference_appendices/config.html#transform-invalid-group-chars